### PR TITLE
Refactired functionality of  a method in RecurrentAutoEncoder

### DIFF
--- a/models/autoencoder/autoencoder.py
+++ b/models/autoencoder/autoencoder.py
@@ -64,13 +64,13 @@ class FlattenDenseLayer(Layer):
 
     def call(self, inputs, *args, **kwargs):
         """
-        Calls the model on new inputs and returns the outputs as tensors, encoding the input tensor in the latent space
-        and trying to reconstruct the input it from this latent representation.
+        Calls the model on new inputs and returns the outputs as tensors, flattening the input tensors on a single
+        dimension, and passing them to the dense layer.
 
         :param inputs: Input tensor, or dict/list/tuple of input tensors.
         :param args: Additional positional arguments. May contain tensors, although this is not recommended.
         :param kwargs: Additional keyword arguments. May contain tensors, although this is not recommended.
-        :return: A tensor or list/tuple of tensors.
+        :return: A tensor or list/tuple of tensors containing the flattened inputs passed through a dense layer.
         """
         flattened = self._flatten_layer(inputs)
         dense_output = self._dense(flattened)
@@ -94,7 +94,7 @@ class FlattenDenseLayer(Layer):
         """
         Computes the output shape of the layer.
 
-        :param input_shape: hape tuple (tuple of integers) or list of shape tuples (one per output tensor of the layer).
+        :param input_shape: shape tuple (tuple of integers) or list of shape tuples (one per output tensor of the layer).
             Shape tuples can include None for free dimensions, instead of an integer.
         :return: An input shape tuple.
         """
@@ -104,7 +104,7 @@ class FlattenDenseLayer(Layer):
     @property
     def units(self) -> int:
         """
-        Return the units number of the dense layer
+        Returns the units number of the dense layer
 
         :return: An integer representing the number of units of the dense layer
         """
@@ -200,7 +200,7 @@ class AutoEncoder(keras.models.Model):
 
         # Compute encoder output shape and decoder (temporary) output shape (batch_size, other dimensions...)
         encoder_output_shape = self._encoder.compute_output_shape(input_shape)
-        self._latent_space_dim = encoder_output_shape[-1]  # number of features in latent space
+        self._latent_space_dim = bottleneck.units  # number of features in latent space
         decoder_output_shape = self._decoder.compute_output_shape(encoder_output_shape)
 
         if add_last_dense_block:

--- a/models/autoencoder/recurrent_autoencoder.py
+++ b/models/autoencoder/recurrent_autoencoder.py
@@ -1,15 +1,372 @@
 from typing import Iterable, final, Optional, Union
-
 from keras import Sequential
-
 from autoencoder import AutoEncoder
 from keras.layers import GRU, LSTM, RepeatVector, Layer
 from keras.losses import MSE
 
 
+class LSTMRepeatVector(Layer):
+    """
+    This class represents a simple neural network layer composed of an LSTM layer and a RepeatVector layer.
+    """
+    def __init__(self, units: int, repeat_vector_timesteps: int, activation='tanh', recurrent_activation='sigmoid',
+                 use_bias: bool = True, kernel_initializer='glorot_uniform', recurrent_initializer='orthogonal',
+                 bias_initializer='zeros', unit_forget_bias: bool = True, kernel_regularizer=None,
+                 recurrent_regularizer=None, bias_regularizer=None, activity_regularizer=None, kernel_constraint=None,
+                 recurrent_constraint=None, bias_constraint=None, dropout: float = 0., recurrent_dropout: float = 0.,
+                 return_state: bool = False, go_backwards: bool = False, stateful: bool = False, unroll: bool = False,
+                 name: Optional[str] = None, rec_name: Optional[str] = None, repeat_vector_name: Optional[str] = None,
+                 **kwargs):
+        """Long Short-Term Memory layer - Hochreiter 1997, with a RepeatVector layer stacked on top.
+
+        Note that this cell is not optimized for performance on GPU. Please use
+        `tf.compat.v1.keras.layers.CuDNNLSTM` for better performance on GPU.
+
+        Args:
+        units: Positive integer, dimensionality of the output space.
+        repeat_vector_timesteps: Positive integer, represents the number of timesteps in which the output vector of the
+            LSTM cell will be repeated.
+        activation: Activation function to use.
+          Default: hyperbolic tangent (`tanh`).
+          If you pass `None`, no activation is applied
+          (ie. "linear" activation: `a(x) = x`).
+        recurrent_activation: Activation function to use
+          for the recurrent step.
+          Default: hard sigmoid (`hard_sigmoid`).
+          If you pass `None`, no activation is applied
+          (ie. "linear" activation: `a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        kernel_initializer: Initializer for the `kernel` weights matrix,
+          used for the linear transformation of the inputs..
+        recurrent_initializer: Initializer for the `recurrent_kernel`
+          weights matrix,
+          used for the linear transformation of the recurrent state.
+        bias_initializer: Initializer for the bias vector.
+        unit_forget_bias: Boolean.
+          If True, add 1 to the bias of the forget gate at initialization.
+          Setting it to true will also force `bias_initializer="zeros"`.
+          This is recommended in [Jozefowicz et al., 2015](
+            http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf).
+        kernel_regularizer: Regularizer function applied to
+          the `kernel` weights matrix.
+        recurrent_regularizer: Regularizer function applied to
+          the `recurrent_kernel` weights matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+          the output of the layer (its "activation").
+        kernel_constraint: Constraint function applied to
+          the `kernel` weights matrix.
+        recurrent_constraint: Constraint function applied to
+          the `recurrent_kernel` weights matrix.
+        bias_constraint: Constraint function applied to the bias vector.
+        dropout: Float between 0 and 1.
+          Fraction of the units to drop for
+          the linear transformation of the inputs.
+        recurrent_dropout: Float between 0 and 1.
+          Fraction of the units to drop for
+          the linear transformation of the recurrent state.
+        return_state: Boolean. Whether to return the last state
+          in addition to the output.
+        go_backwards: Boolean (default False).
+          If True, process the input sequence backwards and return the
+          reversed sequence.
+        stateful: Boolean (default False). If True, the last state
+          for each sample at index i in a batch will be used as initial
+          state for the sample of index i in the following batch.
+        unroll: Boolean (default False).
+          If True, the network will be unrolled,
+          else a symbolic loop will be used.
+          Unrolling can speed-up a RNN,
+          although it tends to be more memory-intensive.
+          Unrolling is only suitable for short sequences.
+        time_major: The shape format of the `inputs` and `outputs` tensors.
+          If True, the inputs and outputs will be in shape
+          `(timesteps, batch, ...)`, whereas in the False case, it will be
+          `(batch, timesteps, ...)`. Using `time_major = True` is a bit more
+          efficient because it avoids transposes at the beginning and end of the
+          RNN calculation. However, most TensorFlow data is batch-major, so by
+          default this function accepts input and emits output in batch-major
+          form.
+        name: a string (default None) representing the name of the layer.
+        rec_name: a string (default None) representing the name of the LSTM cell composing the layer.
+        repeat_vector_name: a string (default None) representing the name of the RepeatVector part of the layer.
+
+        Call arguments:
+        inputs: A 3D tensor.
+        mask: Binary tensor of shape `(samples, timesteps)` indicating whether
+          a given timestep should be masked. An individual `True` entry indicates
+          that the corresponding timestep should be utilized, while a `False`
+          entry indicates that the corresponding timestep should be ignored.
+        training: Python boolean indicating whether the layer should behave in
+          training mode or in inference mode. This argument is passed to the cell
+          when calling it. This is only relevant if `dropout` or
+          `recurrent_dropout` is used.
+        initial_state: List of initial state tensors to be passed to the first
+          call of the cell.
+        """
+        super(LSTMRepeatVector, self).__init__(trainable=True, name=name)
+        self.__lstm = LSTM(
+            units=units,
+            activation=activation,
+            recurrent_activation=recurrent_activation,
+            use_bias=use_bias,
+            kernel_initializer=kernel_initializer,
+            recurrent_initializer=recurrent_initializer,
+            bias_initializer=bias_initializer,
+            unit_forget_bias=unit_forget_bias,
+            kernel_regularizer=kernel_regularizer,
+            recurrent_regularizer=recurrent_regularizer,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer,
+            kernel_constraint=kernel_constraint,
+            recurrent_constraint=recurrent_constraint,
+            bias_constraint=bias_constraint,
+            dropout=dropout,
+            recurrent_dropout=recurrent_dropout,
+            return_state=return_state,
+            go_backwards=go_backwards,
+            stateful=stateful,
+            unroll=unroll,
+            name=rec_name,
+            **kwargs
+        )
+        self.__repeat_vector = RepeatVector(name=repeat_vector_name, n=repeat_vector_timesteps)
+
+    def call(self, inputs, *args, **kwargs):
+        """
+        Calls the model on new inputs and returns the outputs as tensors, feeding the LSTM cell and then repeating the
+        output vector n times.
+
+        :param inputs: Input tensor, or dict/list/tuple of input tensors.
+        :param args: Additional positional arguments. May contain tensors, although this is not recommended.
+        :param kwargs: Additional keyword arguments. May contain tensors, although this is not recommended.
+        :return: A tensor or list/tuple of tensors containing the output of the LSTM cell repeated n times.
+        """
+        lstm_output = self.__lstm(inputs)
+        repeat_vector_output = self.__repeat_vector(lstm_output)
+        return repeat_vector_output
+
+    def build(self, input_shape):
+        """
+        Creates the variables of the layer.
+
+        :param input_shape: Instance of `TensorShape`, or list of instances of `TensorShape` if the layer expects a list
+            of inputs (one instance per input).
+        """
+        self.__lstm.build(input_shape)
+        lstm_output_shape = self.__lstm.compute_output_shape(input_shape)
+        self.__repeat_vector.build(lstm_output_shape)
+        super(LSTMRepeatVector, self).build(input_shape)
+
+    def compute_output_shape(self, input_shape):
+        """
+        Computes the output shape of the layer.
+
+        :param input_shape: hape tuple (tuple of integers) or list of shape tuples (one per output tensor of the layer).
+            Shape tuples can include None for free dimensions, instead of an integer.
+        :return: An input shape tuple.
+        """
+        lstm_output_shape = self.__lstm.compute_output_shape(input_shape)
+        return self.__repeat_vector.compute_output_shape(lstm_output_shape)
+
+    @property
+    def units(self) -> int:
+        """
+        Returns the units number of the LSTM layer.
+
+        :return: An integer representing the number of units of the LSTM layer.
+        """
+        return self.__lstm.units
+
+
+class GRURepeatVector(Layer):
+    """
+    This class represents a simple neural network layer composed of an LSTM layer and a RepeatVector layer.
+    """
+    def __init__(self, units: int, repeat_vector_timesteps: int, activation='tanh', recurrent_activation='sigmoid',
+                 use_bias: bool = True, kernel_initializer='glorot_uniform', recurrent_initializer='orthogonal',
+                 bias_initializer='zeros', kernel_regularizer=None, recurrent_regularizer=None, bias_regularizer=None,
+                 activity_regularizer=None, kernel_constraint=None, recurrent_constraint=None, bias_constraint=None,
+                 dropout: float = 0., recurrent_dropout: float = 0., return_state: bool = False,
+                 go_backwards: bool = False, stateful: bool = False, unroll: bool = False, reset_after: bool = False,
+                 name: Optional[str] = None, rec_name: Optional[str] = None, repeat_vector_name: Optional[str] = None,
+                 **kwargs):
+        """Gated Recurrent Unit - Cho et al. 2014,  with a RepeatVector layer stacked on top.
+
+        There are two variants. The default one is based on 1406.1078v3 and
+        has reset gate applied to hidden state before matrix multiplication. The
+        other one is based on original 1406.1078v1 and has the order reversed.
+
+        The second variant is compatible with CuDNNGRU (GPU-only) and allows
+        inference on CPU. Thus it has separate biases for `kernel` and
+        `recurrent_kernel`. Use `'reset_after'=True` and
+        `recurrent_activation='sigmoid'`.
+
+        Args:
+          units: Positive integer, dimensionality of the output space.
+          repeat_vector_timesteps: Positive integer, represents the number of timesteps in which the output vector of
+          the GRU cell will be repeated.
+          activation: Activation function to use.
+            Default: hyperbolic tangent (`tanh`).
+            If you pass `None`, no activation is applied
+            (ie. "linear" activation: `a(x) = x`).
+          recurrent_activation: Activation function to use
+            for the recurrent step.
+            Default: hard sigmoid (`hard_sigmoid`).
+            If you pass `None`, no activation is applied
+            (ie. "linear" activation: `a(x) = x`).
+          use_bias: Boolean, whether the layer uses a bias vector.
+          kernel_initializer: Initializer for the `kernel` weights matrix,
+            used for the linear transformation of the inputs.
+          recurrent_initializer: Initializer for the `recurrent_kernel`
+            weights matrix, used for the linear transformation of the recurrent state.
+          bias_initializer: Initializer for the bias vector.
+          kernel_regularizer: Regularizer function applied to
+            the `kernel` weights matrix.
+          recurrent_regularizer: Regularizer function applied to
+            the `recurrent_kernel` weights matrix.
+          bias_regularizer: Regularizer function applied to the bias vector.
+          activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation")..
+          kernel_constraint: Constraint function applied to
+            the `kernel` weights matrix.
+          recurrent_constraint: Constraint function applied to
+            the `recurrent_kernel` weights matrix.
+          bias_constraint: Constraint function applied to the bias vector.
+          dropout: Float between 0 and 1.
+            Fraction of the units to drop for
+            the linear transformation of the inputs.
+          recurrent_dropout: Float between 0 and 1.
+            Fraction of the units to drop for
+            the linear transformation of the recurrent state.
+          return_sequences: Boolean. Whether to return the last output
+            in the output sequence, or the full sequence.
+          return_state: Boolean. Whether to return the last state
+            in addition to the output.
+          go_backwards: Boolean (default False).
+            If True, process the input sequence backwards and return the
+            reversed sequence.
+          stateful: Boolean (default False). If True, the last state
+            for each sample at index i in a batch will be used as initial
+            state for the sample of index i in the following batch.
+          unroll: Boolean (default False).
+            If True, the network will be unrolled,
+            else a symbolic loop will be used.
+            Unrolling can speed-up a RNN,
+            although it tends to be more memory-intensive.
+            Unrolling is only suitable for short sequences.
+          time_major: The shape format of the `inputs` and `outputs` tensors.
+            If True, the inputs and outputs will be in shape
+            `(timesteps, batch, ...)`, whereas in the False case, it will be
+            `(batch, timesteps, ...)`. Using `time_major = True` is a bit more
+            efficient because it avoids transposes at the beginning and end of the
+            RNN calculation. However, most TensorFlow data is batch-major, so by
+            default this function accepts input and emits output in batch-major
+            form.
+          reset_after: GRU convention (whether to apply reset gate after or
+            before matrix multiplication). False = "before" (default),
+            True = "after" (cuDNN compatible).
+          name: a string (default None) representing the name of the layer.
+          rec_name: a string (default None) representing the name of the GRU cell composing the layer.
+          repeat_vector_name: a string (default None) representing the name of the RepeatVector part of the layer.
+
+        Call arguments:
+          inputs: A 3D tensor.
+          mask: Binary tensor of shape `(samples, timesteps)` indicating whether
+            a given timestep should be masked. An individual `True` entry indicates
+            that the corresponding timestep should be utilized, while a `False`
+            entry indicates that the corresponding timestep should be ignored.
+          training: Python boolean indicating whether the layer should behave in
+            training mode or in inference mode. This argument is passed to the cell
+            when calling it. This is only relevant if `dropout` or
+            `recurrent_dropout` is used.
+          initial_state: List of initial state tensors to be passed to the first
+            call of the cell.
+        """
+
+        super(GRURepeatVector, self).__init__(trainable=True, name=name)
+        self.__gru = GRU(
+            units=units,
+            activation=activation,
+            recurrent_activation=recurrent_activation,
+            use_bias=use_bias,
+            kernel_initializer=kernel_initializer,
+            recurrent_initializer=recurrent_initializer,
+            bias_initializer=bias_initializer,
+            kernel_regularizer=kernel_regularizer,
+            recurrent_regularizer=recurrent_regularizer,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer,
+            kernel_constraint=kernel_constraint,
+            recurrent_constraint=recurrent_constraint,
+            bias_constraint=bias_constraint,
+            dropout=dropout,
+            recurrent_dropout=recurrent_dropout,
+            return_state=return_state,
+            go_backwards=go_backwards,
+            stateful=stateful,
+            unroll=unroll,
+            reset_after=reset_after,
+            name=rec_name,
+            **kwargs
+        )
+        self.__repeat_vector = RepeatVector(name=repeat_vector_name, n=repeat_vector_timesteps)
+
+    def call(self, inputs, *args, **kwargs):
+        """
+        Calls the model on new inputs and returns the outputs as tensors, feeding the GRU cell and then repeating the
+        output vector n times.
+
+        :param inputs: Input tensor, or dict/list/tuple of input tensors.
+        :param args: Additional positional arguments. May contain tensors, although this is not recommended.
+        :param kwargs: Additional keyword arguments. May contain tensors, although this is not recommended.
+        :return: A tensor or list/tuple of tensors containing the output of the GRU cell repeated n times.
+        """
+        gru_output = self.__gru(inputs)
+        repeat_vector_output = self.__repeat_vector(gru_output)
+        return repeat_vector_output
+
+    def build(self, input_shape):
+        """
+        Creates the variables of the layer.
+
+        :param input_shape: Instance of `TensorShape`, or list of instances of `TensorShape` if the layer expects a list
+            of inputs (one instance per input).
+        """
+        self.__gru.build(input_shape)
+        gru_output_shape = self.__gru.compute_output_shape(input_shape)
+        self.__repeat_vector.build(gru_output_shape)
+        super(GRURepeatVector, self).build(input_shape)
+
+    def compute_output_shape(self, input_shape):
+        """
+        Computes the output shape of the layer.
+
+        :param input_shape: hape tuple (tuple of integers) or list of shape tuples (one per output tensor of the layer).
+            Shape tuples can include None for free dimensions, instead of an integer.
+        :return: An input shape tuple.
+        """
+        gru_output_shape = self.__gru.compute_output_shape(input_shape)
+        return self.__repeat_vector.compute_output_shape(gru_output_shape)
+
+    @property
+    def units(self) -> int:
+        """
+        Returns the units number of the GRU layer.
+
+        :return: An integer representing the number of units of the GRU layer.
+        """
+        return self.__gru.units
+
+
 _UNIT_TYPES: final = {
     "GRU": GRU,
     "LSTM": LSTM
+}
+
+_UNIT_TYPES_RV: final = {
+    "GRU": GRURepeatVector,
+    "LSTM": LSTMRepeatVector
 }
 
 
@@ -206,10 +563,14 @@ class RecurrentAutoEncoder(AutoEncoder):
                 go_backwards=self._go_backwards
             )
         else:
-            bottleneck = Sequential(name="bottleneck_layer")
-            bottleneck.add(constructor(
-                name=f"bottleneck_{unit_type.lower()}",
+            # If bottleneck doesn't return sequences, add a RepeatVector layer prior to the decoder
+            constructor = _UNIT_TYPES_RV[unit_type]
+            bottleneck = constructor(
+                name="bottleneck_layer",
+                rec_name=f"bottleneck_{unit_type.lower()}",
+                repeat_vector_name="bottleneck_repeat_vector",
                 units=units,
+                repeat_vector_timesteps=timesteps,
                 activation=activation,
                 recurrent_activation=recurrent_activation,
                 kernel_initializer=self._kernel_initializer,
@@ -221,11 +582,8 @@ class RecurrentAutoEncoder(AutoEncoder):
                 recurrent_regularizer=self._recurrent_regularizer,
                 dropout=self._recurrent_units_dropout,
                 recurrent_dropout=self._recurrent_dropout,
-                return_sequences=False,
                 go_backwards=self._go_backwards
-            ))
-            # If bottleneck doesn't return sequences, add a RepeatVector layer prior to the decoder
-            bottleneck.add(RepeatVector(name="bottleneck_repeat_vector", n=timesteps))
+            )
 
         return bottleneck
 


### PR DESCRIPTION
Refactored functionality of a RecurrentAutoEncoder protected method, in the case the bottleneck layer must not return sequences, creating two new classes: LSTMRepeatVector and GRURepeatVector.