### PR TITLE
Renamed directory and fixed some wrong constants

### DIFF
--- a/preprocessing/constants.py
+++ b/preprocessing/constants.py
@@ -9,8 +9,8 @@ N_MIX_LPCCS: final = 2
 N_STATES_MEL_SPEC: final = 3
 N_MIX_MEL_SPEC: final = 2
 ACOUSTIC_MODEL_PATH: final = "acoustic_models/"
-ACOUSTIC_MODEL_PATH_MFCCS: final = ACOUSTIC_MODEL_PATH + "/mfccs/"
-ACOUSTIC_MODEL_PATH_LPCCS: final = ACOUSTIC_MODEL_PATH + "acoustic_models/lpccs/"
+ACOUSTIC_MODEL_PATH_MFCCS: final = ACOUSTIC_MODEL_PATH + "mfccs/"
+ACOUSTIC_MODEL_PATH_LPCCS: final = ACOUSTIC_MODEL_PATH + "lpccs/"
 ACOUSTIC_MODEL_PATH_MEL_SPEC: final = ACOUSTIC_MODEL_PATH + "mel_spec/"
 
 # Preprocessed train/test set-related constants


### PR DESCRIPTION
Renamed acoustic_models_evaluation.py to acoustic_model_evaluation.py.
Fixed some wrong constants in constants.py.
