### PR TITLE
Changed some preprocessing constants and wirtten new train/test split function

### DIFF
--- a/preprocessing/constants.py
+++ b/preprocessing/constants.py
@@ -2,8 +2,8 @@ from typing import final
 
 # Acoustic model-related constants
 TRAIN_PERCENTAGE: final = 0.8
-N_STATES_MFCCS: final = 5
-N_MIX_MFCCS: final = 4
+N_STATES_MFCCS: final = 8  # best according to grid search
+N_MIX_MFCCS: final = 3  # best according to grid search
 N_STATES_LPCCS: final = 4
 N_MIX_LPCCS: final = 2
 N_STATES_MEL_SPEC: final = 3


### PR DESCRIPTION
Changed some preprocessing constants in constants.py.
Changed train/test split to better reflect the speaker identification task, making sure that the train contains 80% of each speaker audios, and test contains 20% of each speaker audios.